### PR TITLE
Store safe osc string representation of names

### DIFF
--- a/src/midiin.cpp
+++ b/src/midiin.cpp
@@ -101,7 +101,9 @@ vector<string> MidiIn::getInputNames()
     vector<string> names(nPorts);
 
     for (int i = 0; i < nPorts; i++) {
-        names[i] = ins.getPortName(i);
+        auto name = ins.getPortName(i);
+        local_utils::safeOscString(name);
+        names[i] = name;
     }
     return names;
 }

--- a/src/midiout.cpp
+++ b/src/midiout.cpp
@@ -69,7 +69,9 @@ vector<string> MidiOut::getOutputNames()
     vector<string> names(nPorts);
 
     for (int i = 0; i < nPorts; i++) {
-        names[i] = outs.getPortName(i);
+        auto name = outs.getPortName(i);
+        local_utils::safeOscString(name);
+        names[i] = name;
     }
     return names;
 }


### PR DESCRIPTION
Note, this is just a quick fix to provide the desired behaviour. We should probably either remove the normalised name field or provide another pair of methosd for listing the normalised names.