### PR TITLE
Fix Runaway portnames and listing of internal virtual ports on LInux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ osmid.sublime-workspace
 *.beam
 .vs/
 *.bak
+.#*

--- a/src/midiin.cpp
+++ b/src/midiin.cpp
@@ -106,6 +106,26 @@ vector<string> MidiIn::getInputNames()
     return names;
 }
 
+vector<string> MidiIn::getNonRtMidiInputNames()
+{
+  vector<string> all_names = getInputNames();
+  vector<string> filtered_names;
+
+  for (int i = 0; i < all_names.size() ; i++) {
+    auto s = all_names[i];
+    if (s.rfind("rtmidi_", 0) == 0) {
+      // The fact that the port name starts with rtmidi tells us that
+      // this is a virtual midi port namecreated by RtMidi - ignore it
+    } else {
+      filtered_names.push_back(s);
+    }
+  }
+
+  return filtered_names;
+
+}
+
+
 void MidiIn::updateMidiDevicesNamesMapping()
 {
     m_midiRtMidiIdToName = MidiIn::getInputNames();

--- a/src/midiin.h
+++ b/src/midiin.h
@@ -38,6 +38,7 @@ public:
     virtual ~MidiIn();
 
     static std::vector<std::string> getInputNames();
+    static std::vector<std::string> getNonRtMidiInputNames();
 
 protected:
     void updateMidiDevicesNamesMapping() override;

--- a/src/midiout.cpp
+++ b/src/midiout.cpp
@@ -75,6 +75,24 @@ vector<string> MidiOut::getOutputNames()
     return names;
 }
 
+vector<string> MidiOut::getNonRtMidiOutputNames()
+{
+  vector<string> all_names = getOutputNames();
+  vector<string> filtered_names;
+
+  for (int i = 0; i < all_names.size() ; i++) {
+    auto s = all_names[i];
+    if (s.rfind("rtmidi_", 0) == 0) {
+      // The fact that the port name starts with rtmidi tells us that
+      // this is a virtual midi port created by RtMidi - ignore it
+    } else {
+      filtered_names.push_back(s);
+    }
+  }
+
+  return filtered_names;
+}
+
 void MidiOut::updateMidiDevicesNamesMapping()
 {
     m_midiRtMidiIdToName = MidiOut::getOutputNames();

--- a/src/midiout.h
+++ b/src/midiout.h
@@ -42,6 +42,7 @@ public:
     void send(const std::vector< unsigned char >* msg);
 
     static std::vector<std::string> getOutputNames();
+    static std::vector<std::string> getNonRtMidiOutputNames();
 
 protected:
     void updateMidiDevicesNamesMapping() override;

--- a/src/sp_midi.cpp
+++ b/src/sp_midi.cpp
@@ -57,7 +57,7 @@ static atomic<bool> g_already_initialized(false);
 void prepareMidiSendProcessorOutputs(unique_ptr<MidiSendProcessor>& midiSendProcessor)
 {
     // Open all MIDI devices. This is what Sonic Pi does
-    vector<string> midiOutputsToOpen = MidiOut::getOutputNames();
+    vector<string> midiOutputsToOpen = MidiOut::getNonRtMidiOutputNames();
     {
         midiSendProcessor->prepareOutputs(midiOutputsToOpen);
     }
@@ -67,7 +67,7 @@ void prepareMidiSendProcessorOutputs(unique_ptr<MidiSendProcessor>& midiSendProc
 void prepareMidiInputs(vector<unique_ptr<MidiIn> >& midiInputs)
 {
     // Should we open all devices, or just the ones passed as parameters?
-    vector<string> midiInputsToOpen = MidiIn::getInputNames();
+    vector<string> midiInputsToOpen = MidiIn::getNonRtMidiInputNames();
 
     midiInputs.clear();
     for (const auto& input : midiInputsToOpen) {
@@ -198,7 +198,7 @@ static char **vector_str_to_c(const vector<string>& vector_str)
 
 char **sp_midi_outs(int *n_list)
 {
-    auto outputs = MidiOut::getOutputNames();
+    auto outputs = MidiOut::getNonRtMidiOutputNames();
     char **c_str_list = vector_str_to_c(outputs);
     *n_list = (int)outputs.size();
     return c_str_list;
@@ -206,7 +206,7 @@ char **sp_midi_outs(int *n_list)
 
 char **sp_midi_ins(int *n_list)
 {
-    auto inputs = MidiIn::getInputNames();
+    auto inputs = MidiIn::getNonRtMidiInputNames();
     char **c_str_list = vector_str_to_c(inputs);
     *n_list = (int)inputs.size();
     return c_str_list;


### PR DESCRIPTION
On Linux RtMidi appears to create a new virtual MIDI port per physical input or output port you wish to open for IO.  This has two negative connotations on Linux:

1. in the GUI, these internal virtual MIDI ports are listed which may confuse users
2. when the user hotswaps a MIDI device, the update trigger scans all new MIDI devices which now includes the newly created MIDI ports (they weren't listed previously as the first scan happened before any MIDI ports were opened). As the virtual MIDI ports were listed, they were automatically connected to (as is also the case with any new physical MIDI device) which then created more additional virtual devices which then got listed in the next scan and opened triggering more virtual devices etc.

This patch targets both of these issues.

A new pair of MIDI input name listing functions have been created. These act similarly to `getInputNames()` and `getOutputNames()` but they also filter out any names that start with `rtmidi_` which are assumed to be one of the virtual ports described above.  These new functions are used for scanning for ports to open which therefore means they won't be automatically connected to - therefore not creating a cascading set of connections and new virtual ports.

We also use these functions to provide the port names up to the Erlang layer. This stops the GUI from listing the internally created virtual ports.

Note: I'm absolutely not a C++ expert - so it may very well be the case that I'm breaking some rule about memory safety and I've introduced a memory leak with an every growing heap of vectors of strings - so this patch should definitely be carefully scrutinized.

This patch also assumes that no realistic port name on any platform starts with the prefix `rtmidi_`. If this stops being the case then this needs to be addressed.