### PR TITLE
Refactor internals

### DIFF
--- a/src/hotplug_thread.h
+++ b/src/hotplug_thread.h
@@ -17,54 +17,54 @@ extern std::unique_ptr<MidiSendProcessor> midiSendProcessor;
 class HotPlugThread
 {
 public:
-  ~HotPlugThread()
-  {
-    if (m_thread.joinable()){
-      m_thread.join();
-    }
-  }
-
-  void startThread(){
-    m_thread = std::thread(&HotPlugThread::run, this);
-  }
-
-  void run()
-  {
-    std::vector<MidiPortInfo> lastAvailableInputPorts = MidiIn::getInputPortInfo();
-    std::vector<MidiPortInfo> lastAvailableOutputPorts = MidiOut::getOutputPortInfo();
-
-    while (!g_threadsShouldFinish){
-
-      std::this_thread::sleep_for(std::chrono::milliseconds(500));
-
-      auto newAvailableInputPorts = MidiIn::getInputPortInfo();
-      // Was something added or removed?
-      if(!((newAvailableInputPorts.size() == lastAvailableInputPorts.size()) &&
-           (std::equal(newAvailableInputPorts.begin(), newAvailableInputPorts.end(), lastAvailableInputPorts.begin())))) {
-        try {
-          prepareMidiInputs(midiInputs);
-        } catch (const std::out_of_range&) {
-          std::cout << "Error opening MIDI inputs" << std::endl;
-        }
-        lastAvailableInputPorts = newAvailableInputPorts;
-      }
-
-      auto newAvailableOutputPorts = MidiOut::getOutputPortInfo();
-      // Was something added or removed?
-      if(!((newAvailableOutputPorts.size() == lastAvailableOutputPorts.size()) &&
-           (std::equal(newAvailableOutputPorts.begin(), newAvailableOutputPorts.end(), lastAvailableOutputPorts.begin())))) {
-        try {
-          prepareMidiSendProcessorOutputs(midiSendProcessor);
-        } catch (const std::out_of_range&) {
-          std::cout << "Error opening MIDI outputs" << std::endl;
+    ~HotPlugThread()
+        {
+            if (m_thread.joinable()){
+                m_thread.join();
+            }
         }
 
-        lastAvailableOutputPorts = newAvailableOutputPorts;
-      }
-
+    void startThread(){
+        m_thread = std::thread(&HotPlugThread::run, this);
     }
-  }
 
-  private:
+    void run()
+        {
+            std::vector<MidiPortInfo> lastAvailableInputPorts = MidiIn::getInputPortInfo();
+            std::vector<MidiPortInfo> lastAvailableOutputPorts = MidiOut::getOutputPortInfo();
+
+            while (!g_threadsShouldFinish){
+
+                std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+                auto newAvailableInputPorts = MidiIn::getInputPortInfo();
+                // Was something added or removed?
+                if(!((newAvailableInputPorts.size() == lastAvailableInputPorts.size()) &&
+                     (std::equal(newAvailableInputPorts.begin(), newAvailableInputPorts.end(), lastAvailableInputPorts.begin())))) {
+                    try {
+                        prepareMidiInputs(midiInputs);
+                    } catch (const std::out_of_range&) {
+                        std::cout << "Error opening MIDI inputs" << std::endl;
+                    }
+                    lastAvailableInputPorts = newAvailableInputPorts;
+                }
+
+                auto newAvailableOutputPorts = MidiOut::getOutputPortInfo();
+                // Was something added or removed?
+                if(!((newAvailableOutputPorts.size() == lastAvailableOutputPorts.size()) &&
+                     (std::equal(newAvailableOutputPorts.begin(), newAvailableOutputPorts.end(), lastAvailableOutputPorts.begin())))) {
+                    try {
+                        prepareMidiSendProcessorOutputs(midiSendProcessor);
+                    } catch (const std::out_of_range&) {
+                        std::cout << "Error opening MIDI outputs" << std::endl;
+                    }
+
+                    lastAvailableOutputPorts = newAvailableOutputPorts;
+                }
+
+            }
+        }
+
+private:
     std::thread m_thread;
-  };
+};

--- a/src/hotplug_thread.h
+++ b/src/hotplug_thread.h
@@ -4,6 +4,7 @@
 #include <string>
 #include "midiin.h"
 #include "midisendprocessor.h"
+#include "midi_port_info.h"
 
 extern std::atomic<bool> g_threadsShouldFinish;
 
@@ -16,39 +17,54 @@ extern std::unique_ptr<MidiSendProcessor> midiSendProcessor;
 class HotPlugThread
 {
 public:
-    ~HotPlugThread()
-    {
-        if (m_thread.joinable()){
-            m_thread.join();
+  ~HotPlugThread()
+  {
+    if (m_thread.joinable()){
+      m_thread.join();
+    }
+  }
+
+  void startThread(){
+    m_thread = std::thread(&HotPlugThread::run, this);
+  }
+
+  void run()
+  {
+    std::vector<MidiPortInfo> lastAvailableInputPorts = MidiIn::getInputPortInfo();
+    std::vector<MidiPortInfo> lastAvailableOutputPorts = MidiOut::getOutputPortInfo();
+
+    while (!g_threadsShouldFinish){
+
+      std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+      auto newAvailableInputPorts = MidiIn::getInputPortInfo();
+      // Was something added or removed?
+      if(!((newAvailableInputPorts.size() == lastAvailableInputPorts.size()) &&
+           (std::equal(newAvailableInputPorts.begin(), newAvailableInputPorts.end(), lastAvailableInputPorts.begin())))) {
+        try {
+          prepareMidiInputs(midiInputs);
+        } catch (const std::out_of_range&) {
+          std::cout << "Error opening MIDI inputs" << std::endl;
         }
-    }
+        lastAvailableInputPorts = newAvailableInputPorts;
+      }
 
-    void startThread(){
-        m_thread = std::thread(&HotPlugThread::run, this);
-    }
-
-    void run()
-    {
-        std::vector<std::string> lastAvailableInputPorts = MidiIn::getInputNames();
-        std::vector<std::string> lastAvailableOutputPorts = MidiOut::getOutputNames();
-        while (!g_threadsShouldFinish){
-            std::this_thread::sleep_for(std::chrono::milliseconds(500));
-            auto newAvailableInputPorts = MidiIn::getInputNames();
-            // Was something added or removed?
-            if (newAvailableInputPorts != lastAvailableInputPorts) {
-                prepareMidiInputs(midiInputs);
-                lastAvailableInputPorts = newAvailableInputPorts;
-            }
-
-            auto newAvailableOutputPorts = MidiOut::getOutputNames();
-            // Was something added or removed?
-            if (newAvailableOutputPorts != lastAvailableOutputPorts) {
-                prepareMidiSendProcessorOutputs(midiSendProcessor);
-                lastAvailableOutputPorts = newAvailableOutputPorts;
-            }
-
+      auto newAvailableOutputPorts = MidiOut::getOutputPortInfo();
+      // Was something added or removed?
+      if(!((newAvailableOutputPorts.size() == lastAvailableOutputPorts.size()) &&
+           (std::equal(newAvailableOutputPorts.begin(), newAvailableOutputPorts.end(), lastAvailableOutputPorts.begin())))) {
+        try {
+          prepareMidiSendProcessorOutputs(midiSendProcessor);
+        } catch (const std::out_of_range&) {
+          std::cout << "Error opening MIDI outputs" << std::endl;
         }
+
+        lastAvailableOutputPorts = newAvailableOutputPorts;
+      }
+
     }
-private:
+  }
+
+  private:
     std::thread m_thread;
-};
+  };

--- a/src/midi_port_info.h
+++ b/src/midi_port_info.h
@@ -25,13 +25,13 @@
 
 struct MidiPortInfo
 {
-  std::string portName;
-  std::string normalizedPortName;
-  int portId;
+    std::string portName;
+    std::string normalizedPortName;
+    int portId;
 
-  bool operator==( const MidiPortInfo& rhs) const {
-    return (portName == rhs.portName) &&
-    (normalizedPortName == rhs.normalizedPortName) &&
-    (portId == rhs.portId);
-  }
+    bool operator==( const MidiPortInfo& rhs) const {
+        return (portName == rhs.portName) &&
+        (normalizedPortName == rhs.normalizedPortName) &&
+        (portId == rhs.portId);
+    }
 };

--- a/src/midi_port_info.h
+++ b/src/midi_port_info.h
@@ -20,32 +20,18 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+
 #pragma once
 
-#include <vector>
-#include <map>
-#include <string>
-#include <memory>
-#include <rtmidi/RtMidi.h>
-#include "midicommon.h"
+struct MidiPortInfo
+{
+  std::string portName;
+  std::string normalizedPortName;
+  int portId;
 
-// This class manages a MIDI output device
-class MidiOut : public MidiCommon {
-public:
-    MidiOut(const std::string& portName, const std::string& normalizedPortName, int portId);
-    MidiOut(const MidiOut&) = delete;
-    MidiOut& operator=(const MidiOut&) = delete;
-
-    ~MidiOut();
-
-    void send(const std::vector< unsigned char >* msg);
-
-    static std::vector<std::string> getNormalizedOutputNames();
-    static std::vector<MidiPortInfo> getOutputPortInfo();
-protected:
-
-
-private:
-    std::unique_ptr<RtMidiOut> m_midiOut;
-    int m_midiPortNumber;
+  bool operator==( const MidiPortInfo& rhs) const {
+    return (portName == rhs.portName) &&
+    (normalizedPortName == rhs.normalizedPortName) &&
+    (portId == rhs.portId);
+  }
 };

--- a/src/midicommon.cpp
+++ b/src/midicommon.cpp
@@ -76,7 +76,7 @@ unsigned int MidiCommon::getStickyIdFromName(const string& portName)
 
 std::vector<MidiPortInfo> MidiCommon::getPortInfo(RtMidi& ports)
 {
-    // int nPorts = ports.getPortCount();
+    int nPorts = ports.getPortCount();
     std::vector<MidiPortInfo> connectedInputPortsInfo;
 
     for (int i = 0; i < nPorts; i++) {

--- a/src/midicommon.cpp
+++ b/src/midicommon.cpp
@@ -76,56 +76,56 @@ unsigned int MidiCommon::getStickyIdFromName(const string& portName)
 
 std::vector<MidiPortInfo> MidiCommon::getPortInfo(RtMidi& ports)
 {
-  int nPorts = ports.getPortCount();
-  std::vector<MidiPortInfo> connectedInputPortsInfo;
+    // int nPorts = ports.getPortCount();
+    std::vector<MidiPortInfo> connectedInputPortsInfo;
 
-  for (int i = 0; i < nPorts; i++) {
-    auto name = ports.getPortName(i);
+    for (int i = 0; i < nPorts; i++) {
+        auto name = ports.getPortName(i);
 
-    if (name.rfind("rtmidi_", 0) == 0) {
-      // The fact that the port name starts with rtmidi tells us that
-      // this is a virtual midi port namecreated by RtMidi - ignore it
-    } else {
+        if (name.rfind("rtmidi_", 0) == 0) {
+            // The fact that the port name starts with rtmidi tells us that
+            // this is a virtual midi port namecreated by RtMidi - ignore it
+        } else {
 
-      auto normalizedPortName = name;
-      local_utils::safeOscString(normalizedPortName);
+            auto normalizedPortName = name;
+            local_utils::safeOscString(normalizedPortName);
 
-      // Now we need to check for duplicate port names and if they exist,
-      // append an integer count to subsequent port names to ensure that
-      // they are all unique.  So if there were three devices
-      // simultaneously connected all with the port name
-      // nanokontrol_slider_knob, their "safe names" will become:
-      //
-      // nanokontrol_slider_knob
-      // nanokontrol_slider_knob_2
-      // nanokontrol_slider_knob_3
+            // Now we need to check for duplicate port names and if they exist,
+            // append an integer count to subsequent port names to ensure that
+            // they are all unique.  So if there were three devices
+            // simultaneously connected all with the port name
+            // nanokontrol_slider_knob, their "safe names" will become:
+            //
+            // nanokontrol_slider_knob
+            // nanokontrol_slider_knob_2
+            // nanokontrol_slider_knob_3
 
-      int cnt = 1;
-      for (int j = 0; j < connectedInputPortsInfo.size(); j++) {
-        if(connectedInputPortsInfo[j].normalizedPortName == normalizedPortName) {
-          cnt += 1;
+            int cnt = 1;
+            for (int j = 0; j < connectedInputPortsInfo.size(); j++) {
+                if(connectedInputPortsInfo[j].normalizedPortName == normalizedPortName) {
+                    cnt += 1;
+                }
+            }
+
+            if(cnt != 1) {
+                normalizedPortName += "_";
+                normalizedPortName += std::to_string(cnt);
+            }
+
+            MidiPortInfo info{name, normalizedPortName, i};
+            connectedInputPortsInfo.push_back(info);
         }
-      }
-
-      if(cnt != 1) {
-        normalizedPortName += "_";
-        normalizedPortName += std::to_string(cnt);
-      }
-
-    MidiPortInfo info{name, normalizedPortName, i};
-    connectedInputPortsInfo.push_back(info);
     }
-  }
-  return connectedInputPortsInfo;
+    return connectedInputPortsInfo;
 }
 
 vector<string> MidiCommon::getNormalizedNamesFromPortInfos(std::vector<MidiPortInfo>& info)
 {
-  vector<string> all_names;
+    vector<string> all_names;
 
-  for (int i = 0; i < info.size() ; i++) {
-    auto s = info[i];
-    all_names.push_back(s.normalizedPortName);
-  }
-  return all_names;
+    for (int i = 0; i < info.size() ; i++) {
+        auto s = info[i];
+        all_names.push_back(s.normalizedPortName);
+    }
+    return all_names;
 }

--- a/src/midicommon.cpp
+++ b/src/midicommon.cpp
@@ -22,6 +22,7 @@
 
 #include <iostream>
 #include "midicommon.h"
+#include "utils.h"
 
 using namespace std;
 
@@ -71,4 +72,60 @@ unsigned int MidiCommon::addNameToStickyTable(const string& portName)
 unsigned int MidiCommon::getStickyIdFromName(const string& portName)
 {
     return m_midiNameToStickyId[portName];
+}
+
+std::vector<MidiPortInfo> MidiCommon::getPortInfo(RtMidi& ports)
+{
+  int nPorts = ports.getPortCount();
+  std::vector<MidiPortInfo> connectedInputPortsInfo;
+
+  for (int i = 0; i < nPorts; i++) {
+    auto name = ports.getPortName(i);
+
+    if (name.rfind("rtmidi_", 0) == 0) {
+      // The fact that the port name starts with rtmidi tells us that
+      // this is a virtual midi port namecreated by RtMidi - ignore it
+    } else {
+
+      auto normalizedPortName = name;
+      local_utils::safeOscString(normalizedPortName);
+
+      // Now we need to check for duplicate port names and if they exist,
+      // append an integer count to subsequent port names to ensure that
+      // they are all unique.  So if there were three devices
+      // simultaneously connected all with the port name
+      // nanokontrol_slider_knob, their "safe names" will become:
+      //
+      // nanokontrol_slider_knob
+      // nanokontrol_slider_knob_2
+      // nanokontrol_slider_knob_3
+
+      int cnt = 1;
+      for (int j = 0; j < connectedInputPortsInfo.size(); j++) {
+        if(connectedInputPortsInfo[j].normalizedPortName == normalizedPortName) {
+          cnt += 1;
+        }
+      }
+
+      if(cnt != 1) {
+        normalizedPortName += "_";
+        normalizedPortName += std::to_string(cnt);
+      }
+
+    MidiPortInfo info{name, normalizedPortName, i};
+    connectedInputPortsInfo.push_back(info);
+    }
+  }
+  return connectedInputPortsInfo;
+}
+
+vector<string> MidiCommon::getNormalizedNamesFromPortInfos(std::vector<MidiPortInfo>& info)
+{
+  vector<string> all_names;
+
+  for (int i = 0; i < info.size() ; i++) {
+    auto s = info[i];
+    all_names.push_back(s.normalizedPortName);
+  }
+  return all_names;
 }

--- a/src/midicommon.h
+++ b/src/midicommon.h
@@ -29,6 +29,8 @@
 #include <map>
 #include <string>
 #include "monitorlogger.h"
+#include "midi_port_info.h"
+#include <rtmidi/RtMidi.h>
 
 // This class manages the common parts of our MIDI handling, like sticky ids
 class MidiCommon {
@@ -44,12 +46,12 @@ public:
     int getPortId() const;
 
     static int getRtMidiIdFromName(const std::string& portName);
-
-protected:
-    virtual void updateMidiDevicesNamesMapping() = 0;
     std::string m_portName;
     std::string m_normalizedPortName;
     int m_rtMidiId;
+protected:
+
+
     int m_stickyId;
     static bool nameInStickyTable(const std::string& portName);
     unsigned int addNameToStickyTable(const std::string& portName);
@@ -59,4 +61,7 @@ protected:
     static std::map<std::string, int> m_midiNameToStickyId;
     static unsigned int m_nStickyIds;
     MonitorLogger &m_logger{ MonitorLogger::getInstance() };
+    static std::vector<MidiPortInfo> getPortInfo(RtMidi& ports);
+    static std::vector<std::string> getNormalizedNamesFromPortInfos(std::vector<MidiPortInfo>& info);
+
 };

--- a/src/midiin.cpp
+++ b/src/midiin.cpp
@@ -24,31 +24,25 @@
 #include "sp_midi.h"
 #include "midiin.h"
 #include "utils.h"
+#include "midi_port_info.h"
 
 using namespace std;
 
-MidiIn::MidiIn(const string& portName, bool isVirtual) : m_oscRawMidiMessage(false)
+MidiIn::MidiIn(const string& portName, const string& normalizedPortName, int portId, bool isVirtual) : m_oscRawMidiMessage(false)
 {
     m_logger.debug("MidiIn constructor for {}", portName);
-    updateMidiDevicesNamesMapping();
     m_portName = portName;
-    m_normalizedPortName = portName;
-    local_utils::safeOscString(m_normalizedPortName);
-
-    if (!nameInStickyTable(m_portName))
-        m_stickyId = addNameToStickyTable(m_portName);
-    else
-        m_stickyId = getStickyIdFromName(m_portName);
+    m_normalizedPortName = normalizedPortName;
 
     // FIXME: need to check if name does not exist
     if (!isVirtual) {
-        m_rtMidiId = getRtMidiIdFromName(m_portName);
-        m_midiIn = make_unique<RtMidiIn>();
-        m_midiIn->openPort(m_rtMidiId);
-        m_midiIn->ignoreTypes( false, false, false );
+      m_rtMidiId = portId;
+      m_midiIn = make_unique<RtMidiIn>();
+      m_midiIn->openPort(m_rtMidiId);
+      m_midiIn->ignoreTypes( false, false, false );
     }
 // TODO: do the virtual ports
-#if 0    
+#if 0
     else {
 #ifndef WIN32
         m_logger.trace("*** Creating new MIDI device: ", m_portName);
@@ -72,7 +66,7 @@ MidiIn::~MidiIn()
 
 
 void MidiIn::staticMidiCallback(double timeStamp, std::vector< unsigned char > *midiMessage, void *userData)
-{    
+{
     MidiIn *midiIn = (MidiIn *)userData;
     midiIn->midiCallback(timeStamp, midiMessage);
 }
@@ -90,46 +84,15 @@ void MidiIn::midiCallback(double timeStamp, std::vector< unsigned char > *midiMe
     send_midi_osc_to_erlang(getNormalizedPortName().c_str(), midiMessage->data(), midiMessage->size());
 }
 
-
-
-vector<string> MidiIn::getInputNames()
+vector<MidiPortInfo> MidiIn::getInputPortInfo()
 {
-    RtMidiIn ins;
-    int nPorts = ins.getPortCount();
-    vector<string> names(nPorts);
-
-    for (int i = 0; i < nPorts; i++) {
-        auto name = ins.getPortName(i);
-        local_utils::safeOscString(name);
-        names[i] = name;
-    }
-    return names;
+  RtMidiIn ins;
+  auto ins_info = getPortInfo(ins);
+  return ins_info;
 }
 
-vector<string> MidiIn::getNonRtMidiInputNames()
+vector<string> MidiIn::getNormalizedInputNames()
 {
-  vector<string> all_names = getInputNames();
-  vector<string> filtered_names;
-
-  for (int i = 0; i < all_names.size() ; i++) {
-    auto s = all_names[i];
-    if (s.rfind("rtmidi_", 0) == 0) {
-      // The fact that the port name starts with rtmidi tells us that
-      // this is a virtual midi port namecreated by RtMidi - ignore it
-    } else {
-      filtered_names.push_back(s);
-    }
-  }
-
-  return filtered_names;
-
-}
-
-
-void MidiIn::updateMidiDevicesNamesMapping()
-{
-    m_midiRtMidiIdToName = MidiIn::getInputNames();
-    for (int i = 0; i < m_midiRtMidiIdToName.size(); i++) {
-        m_midiNameToRtMidiId[m_midiRtMidiIdToName[i]] = i;
-    }
+  vector<MidiPortInfo> info = getInputPortInfo();
+  return getNormalizedNamesFromPortInfos(info);
 }

--- a/src/midiin.cpp
+++ b/src/midiin.cpp
@@ -36,10 +36,10 @@ MidiIn::MidiIn(const string& portName, const string& normalizedPortName, int por
 
     // FIXME: need to check if name does not exist
     if (!isVirtual) {
-      m_rtMidiId = portId;
-      m_midiIn = make_unique<RtMidiIn>();
-      m_midiIn->openPort(m_rtMidiId);
-      m_midiIn->ignoreTypes( false, false, false );
+        m_rtMidiId = portId;
+        m_midiIn = make_unique<RtMidiIn>();
+        m_midiIn->openPort(m_rtMidiId);
+        m_midiIn->ignoreTypes( false, false, false );
     }
 // TODO: do the virtual ports
 #if 0
@@ -86,13 +86,13 @@ void MidiIn::midiCallback(double timeStamp, std::vector< unsigned char > *midiMe
 
 vector<MidiPortInfo> MidiIn::getInputPortInfo()
 {
-  RtMidiIn ins;
-  auto ins_info = getPortInfo(ins);
-  return ins_info;
+    RtMidiIn ins;
+    auto ins_info = getPortInfo(ins);
+    return ins_info;
 }
 
 vector<string> MidiIn::getNormalizedInputNames()
 {
-  vector<MidiPortInfo> info = getInputPortInfo();
-  return getNormalizedNamesFromPortInfos(info);
+    vector<MidiPortInfo> info = getInputPortInfo();
+    return getNormalizedNamesFromPortInfos(info);
 }

--- a/src/midiin.h
+++ b/src/midiin.h
@@ -26,23 +26,23 @@
 #include <string>
 #include <rtmidi/RtMidi.h>
 #include "midicommon.h"
+#include "midi_port_info.h"
 
 // This class manages a MIDI input device as seen by JUCE
 class MidiIn : public MidiCommon {
 public:
-    MidiIn(const std::string& portName, bool isVirtual = false);
+  MidiIn(const std::string& portName, const std::string& normalizedPortName, int portId, bool isVirtual = false);
     MidiIn(const MidiIn&) = delete;
     MidiIn& operator=(const MidiIn&) = delete;
 
     virtual ~MidiIn();
 
-    static std::vector<std::string> getInputNames();
-    static std::vector<std::string> getNonRtMidiInputNames();
+    static std::vector<std::string> getNormalizedInputNames();
+    static std::vector<MidiPortInfo> getInputPortInfo();
 
 protected:
-    void updateMidiDevicesNamesMapping() override;
-    std::unique_ptr<RtMidiIn> m_midiIn;
 
+    std::unique_ptr<RtMidiIn> m_midiIn;
     std::mutex m_cb_mutex;
     static void staticMidiCallback(double timeStamp, std::vector< unsigned char > *message, void *userData);
     void midiCallback(double timeStamp, std::vector< unsigned char > *message);

--- a/src/midiin.h
+++ b/src/midiin.h
@@ -31,7 +31,7 @@
 // This class manages a MIDI input device as seen by JUCE
 class MidiIn : public MidiCommon {
 public:
-  MidiIn(const std::string& portName, const std::string& normalizedPortName, int portId, bool isVirtual = false);
+    MidiIn(const std::string& portName, const std::string& normalizedPortName, int portId, bool isVirtual = false);
     MidiIn(const MidiIn&) = delete;
     MidiIn& operator=(const MidiIn&) = delete;
 

--- a/src/midiout.cpp
+++ b/src/midiout.cpp
@@ -26,20 +26,13 @@
 
 using namespace std;
 
-MidiOut::MidiOut(const string& portName)
+MidiOut::MidiOut(const std::string& portName, const std::string& normalizedPortName, int portId)
 {
     m_logger.debug("MidiOut constructor for {}", portName);
-    updateMidiDevicesNamesMapping();
+
     m_portName = portName;
-    m_normalizedPortName = portName;
-    local_utils::safeOscString(m_normalizedPortName);
-
-    if (!nameInStickyTable(m_portName))
-        m_stickyId = addNameToStickyTable(m_portName);
-    else
-        m_stickyId = getStickyIdFromName(m_portName);
-
-    m_rtMidiId = getRtMidiIdFromName(m_portName);
+    m_normalizedPortName = normalizedPortName;
+    m_rtMidiId = portId;
 
     // FIXME: need to check if name does not exist
     m_midiOut = make_unique<RtMidiOut>();
@@ -61,42 +54,15 @@ void MidiOut::send(const std::vector< unsigned char >* msg)
     m_midiOut->sendMessage(msg);
 }
 
-vector<string> MidiOut::getOutputNames()
+vector<MidiPortInfo> MidiOut::getOutputPortInfo()
 {
-    RtMidiOut outs;
-    int nPorts = outs.getPortCount();
-    vector<string> names(nPorts);
-
-    for (int i = 0; i < nPorts; i++) {
-        auto name = outs.getPortName(i);
-        local_utils::safeOscString(name);
-        names[i] = name;
-    }
-    return names;
+  RtMidiOut outs;
+  auto outs_info = getPortInfo(outs);
+  return outs_info;
 }
 
-vector<string> MidiOut::getNonRtMidiOutputNames()
+vector<string> MidiOut::getNormalizedOutputNames()
 {
-  vector<string> all_names = getOutputNames();
-  vector<string> filtered_names;
-
-  for (int i = 0; i < all_names.size() ; i++) {
-    auto s = all_names[i];
-    if (s.rfind("rtmidi_", 0) == 0) {
-      // The fact that the port name starts with rtmidi tells us that
-      // this is a virtual midi port created by RtMidi - ignore it
-    } else {
-      filtered_names.push_back(s);
-    }
-  }
-
-  return filtered_names;
-}
-
-void MidiOut::updateMidiDevicesNamesMapping()
-{
-    m_midiRtMidiIdToName = MidiOut::getOutputNames();
-    for (int i = 0; i < m_midiRtMidiIdToName.size(); i++) {
-        m_midiNameToRtMidiId[m_midiRtMidiIdToName[i]] = i;
-    }
+  vector<MidiPortInfo> info = getOutputPortInfo();
+  return getNormalizedNamesFromPortInfos(info);
 }

--- a/src/midiout.cpp
+++ b/src/midiout.cpp
@@ -56,13 +56,13 @@ void MidiOut::send(const std::vector< unsigned char >* msg)
 
 vector<MidiPortInfo> MidiOut::getOutputPortInfo()
 {
-  RtMidiOut outs;
-  auto outs_info = getPortInfo(outs);
-  return outs_info;
+    RtMidiOut outs;
+    auto outs_info = getPortInfo(outs);
+    return outs_info;
 }
 
 vector<string> MidiOut::getNormalizedOutputNames()
 {
-  vector<MidiPortInfo> info = getOutputPortInfo();
-  return getNormalizedNamesFromPortInfos(info);
+    vector<MidiPortInfo> info = getOutputPortInfo();
+    return getNormalizedNamesFromPortInfos(info);
 }

--- a/src/midisendprocessor.cpp
+++ b/src/midisendprocessor.cpp
@@ -48,7 +48,7 @@ void MidiSendProcessor::prepareOutputs(const vector<MidiPortInfo>& portsInfo)
     m_outputs.clear();
     for (auto& output : portsInfo) {
         try {
-          auto midiOut = make_unique<MidiOut>(output.portName, output.normalizedPortName, output.portId);
+            auto midiOut = make_unique<MidiOut>(output.portName, output.normalizedPortName, output.portId);
             m_outputs.push_back(std::move(midiOut));
         }
         catch (const RtMidiError& e) {

--- a/src/midisendprocessor.cpp
+++ b/src/midisendprocessor.cpp
@@ -43,16 +43,16 @@ MidiSendProcessor::~MidiSendProcessor()
 }
 
 
-void MidiSendProcessor::prepareOutputs(const vector<string>& outputNames)
+void MidiSendProcessor::prepareOutputs(const vector<MidiPortInfo>& portsInfo)
 {
     m_outputs.clear();
-    for (auto& outputName : outputNames) {
+    for (auto& output : portsInfo) {
         try {
-            auto midiOut = make_unique<MidiOut>(outputName);
+          auto midiOut = make_unique<MidiOut>(output.portName, output.normalizedPortName, output.portId);
             m_outputs.push_back(std::move(midiOut));
         }
         catch (const RtMidiError& e) {
-            cout << "Could not open output device " << outputName << ": " << e.what() << endl;
+            cout << "Could not open output device " << output.portName << ": " << e.what() << endl;
             //throw;
         }
     }
@@ -88,7 +88,7 @@ void MidiSendProcessor::run()
     while (!g_threadsShouldFinish){
         bool available = m_messages.wait_dequeue_timed(msg, std::chrono::milliseconds(500));
         if (available && !m_flushing){
-            processMessage(msg);            
+            processMessage(msg);
         }
     }
 }

--- a/src/midisendprocessor.h
+++ b/src/midisendprocessor.h
@@ -40,13 +40,13 @@ private:
         std::vector<unsigned char> midi;
     } MidiDeviceAndMessage;
 
-public:    
+public:
     MidiSendProcessor() : m_flushing(false) {};
     ~MidiSendProcessor();
 
     void startThread();
 
-    void prepareOutputs(const std::vector<std::string>& outputNames);
+    void prepareOutputs(const std::vector<MidiPortInfo>& portsInfo);
 
     void processMessage(const MidiDeviceAndMessage& message_from_c);
 
@@ -73,6 +73,3 @@ private:
     std::atomic<bool> m_flushing;
     void run();
 };
-
-
-

--- a/src/sp_midi.cpp
+++ b/src/sp_midi.cpp
@@ -58,7 +58,7 @@ static atomic<bool> g_already_initialized { false };
 void prepareMidiSendProcessorOutputs(unique_ptr<MidiSendProcessor>& midiSendProcessor)
 {
     // Open all MIDI devices. This is what Sonic Pi does
-      vector<MidiPortInfo> connectedOutputPortsInfo = MidiIn::getInputPortInfo();
+    vector<MidiPortInfo> connectedOutputPortsInfo = MidiIn::getInputPortInfo();
     {
         midiSendProcessor->prepareOutputs(connectedOutputPortsInfo);
     }
@@ -72,9 +72,9 @@ void prepareMidiInputs(vector<unique_ptr<MidiIn> >& midiInputs)
 
     midiInputs.clear();
     for (const auto& input : connectedInputPortsInfo) {
-      try {
-          auto midiInput = make_unique<MidiIn>(input.portName, input.normalizedPortName, input.portId, false);
-          midiInputs.push_back(std::move(midiInput));
+        try {
+            auto midiInput = make_unique<MidiIn>(input.portName, input.normalizedPortName, input.portId, false);
+            midiInputs.push_back(std::move(midiInput));
         } catch (const RtMidiError& e) {
             cout << "Could not open input device " << input.portName << ": " << e.what() << endl;
             //throw;

--- a/src/sp_midi.cpp
+++ b/src/sp_midi.cpp
@@ -32,6 +32,7 @@
 #include "version.h"
 #include "utils.h"
 #include "monitorlogger.h"
+#include "midi_port_info.h"
 
 static int g_monitor_level = 6;
 
@@ -57,9 +58,9 @@ static atomic<bool> g_already_initialized { false };
 void prepareMidiSendProcessorOutputs(unique_ptr<MidiSendProcessor>& midiSendProcessor)
 {
     // Open all MIDI devices. This is what Sonic Pi does
-    vector<string> midiOutputsToOpen = MidiOut::getNonRtMidiOutputNames();
+      vector<MidiPortInfo> connectedOutputPortsInfo = MidiIn::getInputPortInfo();
     {
-        midiSendProcessor->prepareOutputs(midiOutputsToOpen);
+        midiSendProcessor->prepareOutputs(connectedOutputPortsInfo);
     }
 }
 
@@ -67,15 +68,15 @@ void prepareMidiSendProcessorOutputs(unique_ptr<MidiSendProcessor>& midiSendProc
 void prepareMidiInputs(vector<unique_ptr<MidiIn> >& midiInputs)
 {
     // Should we open all devices, or just the ones passed as parameters?
-    vector<string> midiInputsToOpen = MidiIn::getNonRtMidiInputNames();
+    vector<MidiPortInfo> connectedInputPortsInfo = MidiIn::getInputPortInfo();
 
     midiInputs.clear();
-    for (const auto& input : midiInputsToOpen) {
-        try {
-            auto midiInput = make_unique<MidiIn>(input, false);
-            midiInputs.push_back(std::move(midiInput));
+    for (const auto& input : connectedInputPortsInfo) {
+      try {
+          auto midiInput = make_unique<MidiIn>(input.portName, input.normalizedPortName, input.portId, false);
+          midiInputs.push_back(std::move(midiInput));
         } catch (const RtMidiError& e) {
-            cout << "Could not open input device " << input << ": " << e.what() << endl;
+            cout << "Could not open input device " << input.portName << ": " << e.what() << endl;
             //throw;
         }
     }
@@ -185,7 +186,7 @@ static char **vector_str_to_c(const vector<string>& vector_str)
 
 char **sp_midi_outs(int *n_list)
 {
-    auto outputs = MidiOut::getNonRtMidiOutputNames();
+    auto outputs = MidiOut::getNormalizedOutputNames();
     char **c_str_list = vector_str_to_c(outputs);
     *n_list = (int)outputs.size();
     return c_str_list;
@@ -193,7 +194,7 @@ char **sp_midi_outs(int *n_list)
 
 char **sp_midi_ins(int *n_list)
 {
-    auto inputs = MidiIn::getNonRtMidiInputNames();
+    auto inputs = MidiIn::getNormalizedInputNames();
     char **c_str_list = vector_str_to_c(inputs);
     *n_list = (int)inputs.size();
     return c_str_list;


### PR DESCRIPTION
This patch introduces a new struct: MidiPortInfo which is used to help populate lists of connected devices for both reporting back to Erlang and for initialising RtMidi objects.

We now also handle multiple simultaneously connected devices with the same port name and ensure that all listed names are unique (by appending an integer into similarly named ports).