### PR TITLE
Build - use built-in RtMidi by default on Linux

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -26,7 +26,7 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         sudo apt update
-        sudo apt install -y libasound2-dev librtmidi-dev
+        sudo apt install -y libasound2-dev
 
     - name: Linux Elixir
       uses: erlef/setup-beam@v1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 project (sp_midi)
 cmake_minimum_required (VERSION 3.0)
 
+option(USE_SYSTEM_RTMIDI "Use system RtMidi library instead of built-in library (Linux only)" OFF)
+
 set(CMAKE_VERBOSE_MAKEFILE ON)
 
 if(NOT MSVC)
@@ -25,11 +27,14 @@ endif(APPLE)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 if(WIN32)
- include_directories( ${PROJECT_SOURCE_DIR}/external_libs/spdlog-1.8.2/include ${PROJECT_SOURCE_DIR}/external_libs/concurrentqueue ${PROJECT_SOURCE_DIR}/external_libs)
+    include_directories(${PROJECT_SOURCE_DIR}/external_libs/spdlog-1.8.2/include ${PROJECT_SOURCE_DIR}/external_libs/concurrentqueue ${PROJECT_SOURCE_DIR}/external_libs)
 elseif(APPLE)
- include_directories( ${PROJECT_SOURCE_DIR}/external_libs/spdlog-1.8.2/include ${PROJECT_SOURCE_DIR}/external_libs/concurrentqueue ${PROJECT_SOURCE_DIR}/external_libs)
+    include_directories(${PROJECT_SOURCE_DIR}/external_libs/spdlog-1.8.2/include ${PROJECT_SOURCE_DIR}/external_libs/concurrentqueue ${PROJECT_SOURCE_DIR}/external_libs)
 else()
- include_directories(${PROJECT_SOURCE_DIR}/external_libs/spdlog-1.8.2/include ${PROJECT_SOURCE_DIR}/external_libs/concurrentqueue)
+    include_directories(${PROJECT_SOURCE_DIR}/external_libs/spdlog-1.8.2/include ${PROJECT_SOURCE_DIR}/external_libs/concurrentqueue)
+    if(NOT USE_SYSTEM_RTMIDI)
+        include_directories(${PROJECT_SOURCE_DIR}/external_libs)
+    endif(NOT USE_SYSTEM_RTMIDI)
 endif()
 
 set(sp_midi_sources
@@ -44,12 +49,15 @@ set(sp_midi_sources
 if(MSVC)
     list(APPEND sp_midi_sources ${PROJECT_SOURCE_DIR}/external_libs/rtmidi/RtMidi.cpp)
     add_definitions(-D__WINDOWS_MM__)
-endif(MSVC)
-
-if(APPLE)
+elseif(APPLE)
     list(APPEND sp_midi_sources ${PROJECT_SOURCE_DIR}/external_libs/rtmidi/RtMidi.cpp)
     add_definitions(-D__MACOSX_CORE__)
-endif(APPLE)
+elseif(UNIX)
+    if(NOT USE_SYSTEM_RTMIDI)
+        list(APPEND sp_midi_sources ${PROJECT_SOURCE_DIR}/external_libs/rtmidi/RtMidi.cpp)
+        add_definitions(-D__LINUX_ALSA__)
+    endif(NOT USE_SYSTEM_RTMIDI)
+endif(MSVC)
 
 # sp_midi_sources
 add_library(libsp_midi SHARED ${sp_midi_sources})
@@ -78,6 +86,9 @@ elseif(APPLE)
 elseif(UNIX)
     add_definitions(-DLINUX=1 -DNDEBUG=1)
     include_directories(${ERLANG_INCLUDE_PATH})
-    target_link_libraries(libsp_midi pthread ${ALSA_LIBRARY} dl rtmidi)
+    target_link_libraries(libsp_midi pthread ${ALSA_LIBRARY} dl)
+    if(USE_SYSTEM_RTMIDI)
+        target_link_libraries(libsp_midi rtmidi)
+    endif(USE_SYSTEM_RTMIDI)
 endif(MSVC)
 


### PR DESCRIPTION
This follows the discussion in sonic-pi-net/sonic-pi#2542 and updates CMakeLists to default to including RtMidi on Linux, unless it was specifically asked to be excluded using the `USE_SYSTEM_RTMIDI` CMake option (e.g. `cmake -DUSE_SYSTEM_RTMIDI=ON`)

Names of the option or wording or whatever else can be changed if anyone feels it is unclear

Supersedes sonic-pi-net/sonic-pi#2542